### PR TITLE
JobParameters.jobID renamed to JobParameters.jobName

### DIFF
--- a/Sources/HummingbirdJobs/JobDefinition.swift
+++ b/Sources/HummingbirdJobs/JobDefinition.swift
@@ -23,10 +23,27 @@ public struct JobDefinition<Parameters: Codable & Sendable>: Sendable {
     ///   - id: Job identifier
     ///   - maxRetryCount: Maxiumum times this job will be retried if it fails
     ///   - execute: Closure that executes job
-    public init(id: JobIdentifier<Parameters>, maxRetryCount: Int = 0, execute: @escaping @Sendable (Parameters, JobContext) async throws -> Void) {
+    public init(
+        id: JobIdentifier<Parameters>,
+        maxRetryCount: Int = 0,
+        execute: @escaping @Sendable (Parameters, JobContext) async throws -> Void
+    ) {
         self.id = id
         self.maxRetryCount = maxRetryCount
         self._execute = execute
+    }
+
+    ///  Initialize JobDefinition
+    /// - Parameters:
+    ///   - parameters: Job parameter type
+    ///   - maxRetryCount: Maxiumum times this job will be retried if it fails
+    ///   - execute: Closure that executes job
+    public init(
+        parameters: Parameters.Type = Parameters.self,
+        maxRetryCount: Int = 0,
+        execute: @escaping @Sendable (Parameters, JobContext) async throws -> Void
+    ) where Parameters: JobParameters {
+        self.init(id: Parameters.jobID, maxRetryCount: maxRetryCount, execute: execute)
     }
 
     func execute(_ parameters: Parameters, context: JobContext) async throws {

--- a/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
+++ b/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
@@ -201,10 +201,11 @@ final class HummingbirdJobsTests: XCTestCase {
         )
         struct SleepJobParameters: JobParameters {
             static let jobName = "Sleep"
+            let length: Duration
         }
-        jobQueue.registerJob(parameters: SleepJobParameters.self) { _, _ in
+        jobQueue.registerJob(parameters: SleepJobParameters.self) { parameters, _ in
             expectation.fulfill()
-            try await Task.sleep(for: .milliseconds(1000))
+            try await Task.sleep(for: parameters.length)
         }
         try await withThrowingTaskGroup(of: Void.self) { group in
             let serviceGroup = ServiceGroup(
@@ -217,7 +218,7 @@ final class HummingbirdJobsTests: XCTestCase {
             group.addTask {
                 try await serviceGroup.run()
             }
-            try await jobQueue.push(SleepJobParameters())
+            try await jobQueue.push(SleepJobParameters(length: .milliseconds(100)))
             group.cancelAll()
             await self.wait(for: [expectation], timeout: 5)
         }

--- a/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
+++ b/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
@@ -165,7 +165,7 @@ final class HummingbirdJobsTests: XCTestCase {
 
     func testJobParameters() async throws {
         struct TestJobParameters: JobParameters {
-            static let jobID: String = "TestJobParameters"
+            static let jobName: String = "TestJobParameters"
             let id: Int
             let message: String
         }
@@ -185,7 +185,6 @@ final class HummingbirdJobsTests: XCTestCase {
 
     /// Verify test job is cancelled when service group is cancelled
     func testShutdownJob() async throws {
-        let jobIdentifer = JobIdentifier<Int>(#function)
         let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 1)
 
         let cancelledJobCount = ManagedAtomic(0)
@@ -200,7 +199,10 @@ final class HummingbirdJobsTests: XCTestCase {
             numWorkers: 4,
             logger: logger
         )
-        jobQueue.registerJob(id: jobIdentifer) { _, _ in
+        struct SleepJobParameters: JobParameters {
+            static let jobName = "Sleep"
+        }
+        jobQueue.registerJob(parameters: SleepJobParameters.self) { _, _ in
             expectation.fulfill()
             try await Task.sleep(for: .milliseconds(1000))
         }
@@ -215,7 +217,7 @@ final class HummingbirdJobsTests: XCTestCase {
             group.addTask {
                 try await serviceGroup.run()
             }
-            try await jobQueue.push(id: jobIdentifer, parameters: 0)
+            try await jobQueue.push(SleepJobParameters())
             group.cancelAll()
             await self.wait(for: [expectation], timeout: 5)
         }

--- a/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
+++ b/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
@@ -218,7 +218,7 @@ final class HummingbirdJobsTests: XCTestCase {
             group.addTask {
                 try await serviceGroup.run()
             }
-            try await jobQueue.push(SleepJobParameters(length: .milliseconds(100)))
+            try await jobQueue.push(SleepJobParameters(length: .milliseconds(500)))
             group.cancelAll()
             await self.wait(for: [expectation], timeout: 5)
         }

--- a/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
+++ b/Tests/HummingbirdJobsTests/HummingbirdJobsTests.swift
@@ -218,9 +218,9 @@ final class HummingbirdJobsTests: XCTestCase {
             group.addTask {
                 try await serviceGroup.run()
             }
-            try await jobQueue.push(SleepJobParameters(length: .milliseconds(500)))
-            group.cancelAll()
+            try await jobQueue.push(SleepJobParameters(length: .milliseconds(1000)))
             await self.wait(for: [expectation], timeout: 5)
+            group.cancelAll()
         }
 
         XCTAssertEqual(cancelledJobCount.load(ordering: .relaxed), 1)


### PR DESCRIPTION
As `jobID` is the actual `JobIdentifier` while `jobName` is the string used to construct the identifier.
Also make it easier to create a `JobDefinition` by passing in `parameters` parameter instead of having to define it in the attached closure in a similar way you can do it in `JobQueue.registerJob`.
eg
```swift
struct SleepJobParameters: JobParameters {
    static let jobName = "Sleep"
    let length: Duration
}
let job = JobDefinition(parameters: SleepJobParameters.self) { parameters, _ in
    try await Task.sleep(for: parameters.length)
}
```